### PR TITLE
Feature/item

### DIFF
--- a/Assets/01. Scenes/ItemTest.unity
+++ b/Assets/01. Scenes/ItemTest.unity
@@ -3836,10 +3836,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bomb
       objectReference: {fileID: 0}
-    - target: {fileID: 4642828439658819771, guid: 9878e0d0a0321a44b81e425c584adc61, type: 3}
-      propertyPath: m_Radius
-      value: 3
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/01. Scenes/ItemTest.unity
+++ b/Assets/01. Scenes/ItemTest.unity
@@ -1272,7 +1272,7 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 6200000, guid: d34b6c9c7b462be419b1fee6f33fcc98, type: 2}
+  m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -3201,7 +3201,7 @@ Transform:
   m_GameObject: {fileID: 1911206120}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.21, y: -0.21, z: 0}
+  m_LocalPosition: {x: -0.25, y: -0.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/03. Scripts/Item/Inventory/Inventory.cs
+++ b/Assets/03. Scripts/Item/Inventory/Inventory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -129,7 +128,7 @@ public class Inventory : MonoBehaviour
     /// <param name="i"></param>
     public void RemoveItem(int useTag, int i)
     {
-        slots[useTag][i].DecreaseItemCount();
+        slots[useTag][i].ClearSlot();
     }
     #endregion 아이템 상호작용
 
@@ -226,6 +225,40 @@ public class Inventory : MonoBehaviour
         foreach (Slot slot in slots[index])
         {
             slot.UpdateSlotUI();
+        }
+    }
+    
+    /// <summary>
+    /// 모든 Explore Item을 삭제한다.
+    /// </summary>
+    public void DropExploreItems()
+    {
+        for(int i = 0; i < slots.Length; i++)
+        {
+            for (int j = 0; j < slots[i].Count; j++)
+            {
+                // Explore Item에만 동작
+                if (slots[i][j].slotItem == null || slots[i][j].slotItem.itemData.purposeTag != PurposeTag.Explore)
+                {
+                    continue;
+                }
+
+                // 장착 중이라면 해제
+                if (slots[i][j].isEquiped)
+                {
+                    if (slots[i][j].slotItem.itemData.useTag == UseTag.Equip)
+                    {
+                        slots[i][j].UnequipItem();
+                    }
+
+                    else if(slots[i][j].slotItem.itemData.useTag == UseTag.Hand)
+                    {
+                        slots[i][j].UnhandItem();
+                    }
+                }
+
+                slots[i][j].ClearSlot();
+            }
         }
     }
     #endregion 정렬

--- a/Assets/03. Scripts/Item/Inventory/QuickSlot.cs
+++ b/Assets/03. Scripts/Item/Inventory/QuickSlot.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -55,6 +53,7 @@ public class QuickSlot : MonoBehaviour
     public void ClearQuickSlot()
     {
         currentItem = null;
+        currentSlot = null;
         itemImage.sprite = null;
         itemImage.gameObject.SetActive(false);
     }

--- a/Assets/03. Scripts/Item/Inventory/QuickSlot.cs
+++ b/Assets/03. Scripts/Item/Inventory/QuickSlot.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 public class QuickSlot : MonoBehaviour
 {
     private Item currentItem;
-    private Slot currentSlot;
+    public Slot currentSlot;
     private Image itemImage;
 
     private void Awake()

--- a/Assets/03. Scripts/Item/Inventory/Slot.cs
+++ b/Assets/03. Scripts/Item/Inventory/Slot.cs
@@ -7,13 +7,20 @@ using UnityEngine.UI;
 public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, IPointerExitHandler, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler
 {
     #region 변수
+    [Header("아이템")]
     public Item slotItem;
     public Image icon;
+    public bool isEquiped = false;
+
+    [Header("인벤토리")]
     private DragSlot dragSlot;
     private ItemInfoWindow infoWindow;
     private QuickSlot quickSlot;
+
+    [Header("플레이어 정보")]
     private PlayerHand playerHand;
 
+    [Header("이벤트")]
     public UnityEvent[] clickEvent = new UnityEvent[3];
 
     // 현재 슬롯이 장비/장착/소비 슬롯 중 어떤 것인가?
@@ -63,7 +70,6 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
 
         // 핸드 아이템 사용 시
         clickEvent[(int)UseTag.Hand].AddListener(HideInfo);
-        clickEvent[(int)UseTag.Hand].AddListener(HandItemToPlayer);
         clickEvent[(int)UseTag.Hand].AddListener(ToggleHand);
 
         // 소비 아이템 사용 시
@@ -181,10 +187,6 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         dragSlot.SetItem(temp);
     }
 
-    /// <summary>
-    /// 아이템 추가
-    /// </summary>
-    /// <param name="item"></param> 
     public void AddItem(Item item)
     {
         if(item == null)
@@ -203,6 +205,7 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         // 그 외 슬롯에 새 아이템 추가
         slotItem = item;
         item.transform.parent = transform;
+        item.gameObject.SetActive(false);
     }
 
     /// <summary>
@@ -215,11 +218,19 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
             return;
         }
 
-        // 소비 아이템이 아니거나, 소비 아이템의 개수를 1 줄인 후 0 이하일 때 비운다.
+        // 소비 아이템이 아니라면 삭제,
+        // 소비 아이템은 개수를 1 줄인 후 0이라면 비운다.
         if(slotItem.itemData.useTag != UseTag.Consume || --slotItem.count <= 0)
         {
             slotItem = null;
         }
+
+        UpdateSlotUI();
+    }
+
+    public void ClearSlot()
+    {
+        slotItem = null;
 
         UpdateSlotUI();
     }
@@ -251,9 +262,6 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         clickEvent[(int)slotItem.itemData.useTag].Invoke();
     }
 
-    /// <summary>
-    /// Equip/Unequip 상태를 토글한다.
-    /// </summary>
     void ToggleEquip()
     {
         if(slotItem == null)
@@ -261,40 +269,33 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
             return;
         }
 
-        if(slotItem.isEquiped == true)
+        if(isEquiped == true)
         {
             UnequipItem();
-            slotItem.DeactivateItem();
         }
 
         else
         {
             EquipItem();
-            slotItem.ActivateItem();
         }
     }
 
-    /// <summary>
-    /// 아이템을 장착했음을 표시한다.
-    /// </summary>
     void EquipItem()
     {
         itemStatus.SetActive(true);
-        slotItem.isEquiped = true;
+        isEquiped = true;
+
+        slotItem.ActivateItem();
     }
 
-    /// <summary>
-    /// 아이템을 해제했음을 표시한다.
-    /// </summary>
-    void UnequipItem()
+    public void UnequipItem()
     {
         itemStatus.SetActive(false);
-        slotItem.isEquiped = false;
+        isEquiped = false;
+
+        slotItem.DeactivateItem();
     }
 
-    /// <summary>
-    /// Hand 상태를 토글한다.
-    /// </summary>
     void ToggleHand()
     {
         if (slotItem == null)
@@ -302,7 +303,7 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
             return;
         }
 
-        if (slotItem.isEquiped == true)
+        if (isEquiped == true)
         {
             UnhandItem();
         }
@@ -313,28 +314,25 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         }
     }
 
-    /// <summary>
-    /// 아이템을 퀵슬롯에 등록한다.
-    /// </summary>
     void HandItem()
     {
         itemStatus.SetActive(true);
-        slotItem.isEquiped = true;
+        isEquiped = true;
 
         quickSlot.SetInventorySlot(this);
         quickSlot.SetItem(slotItem);
 
-        // 플레이어 손에 든다.
+        HandItemToPlayer();
     }
     
-    /// <summary>
-    /// 아이템을 퀵슬롯에서 해제한다.
-    /// </summary>
     public void UnhandItem()
     {
         itemStatus.SetActive(false);
-        slotItem.isEquiped = false;
+        isEquiped = false;
+
         quickSlot.ClearQuickSlot();
+
+        ReturnItemToSlot();
     }
 
     private void HandItemToPlayer()
@@ -343,20 +341,18 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         slotItem.transform.localPosition = Vector3.zero;
 
         playerHand.HandItem(slotItem);
+        slotItem.gameObject.SetActive(true);
     }
-
 
     private void ReturnItemToSlot()
     {
         slotItem.transform.parent = transform;
+        slotItem.gameObject.SetActive(false);
         slotItem.transform.localPosition = Vector3.zero;
     }
     #endregion 아이템 상호작용
 
     #region UI
-    /// <summary>
-    /// 현재 아이템으로 UI 갱신
-    /// </summary>
     public void UpdateSlotUI()
     {
         if(slotItem == null)
@@ -379,13 +375,10 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         // 그 외 아이템은 장착 여부 최신화
         else
         {
-            itemStatus.SetActive(slotItem.isEquiped);
+            itemStatus.SetActive(isEquiped);
         }
     }
 
-    /// <summary>
-    /// 상세정보 표시
-    /// </summary>
     public void ShowInfo()
     {
         // 아이템이 없다면 띄우지 않는다.
@@ -400,9 +393,6 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
         infoWindow.ShowInfoUI();
     }
 
-    /// <summary>
-    /// 상세정보 숨김
-    /// </summary>
     public void HideInfo()
     {
         // 아이템이 없다면 호출하지 않는다.
@@ -415,10 +405,6 @@ public class Slot : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, I
     }
     #endregion UI
 
-    /// <summary>
-    /// 비어 있는 슬롯이라면 true 반환
-    /// </summary>
-    /// <returns></returns>
     public bool IsEmpty()
     {
         return slotItem == null;

--- a/Assets/03. Scripts/Item/Item/Items/ArmorItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/ArmorItem.cs
@@ -2,16 +2,24 @@ using UnityEngine;
 
 public class ArmorItem : Item
 {
+    private Player player;
+
+    private void Awake()
+    {
+        player = GameObject.FindWithTag("Player").GetComponent<Player>();
+    }
+
     public override void ActivateItem()
     {
-        // 갑옷을 플레이어에게 추가한다.
-        Debug.Log("갑옷 장착");
+        // TODO: 보호막 이펙트를 플레이어에 추가 -> 활성화/비활성화로 조작
+        // player.armor++;, 보호 수준 변경하기
     }
 
 
     public override void DeactivateItem()
     {
-        // 갑옷을 삭제한다.
-        Debug.Log("갑옷 해제");
+        // TODO: 보호막 이펙트를 플레이어에 추가 -> 활성화/비활성화로 조작
+        // player.armor--;, 보호 수준 변경하기
+        // 개인적으론 armor는 0 혹은 1로 하고, 대입으로 세팅하는 게 더 좋을 듯
     }
 }

--- a/Assets/03. Scripts/Item/Item/Items/BombItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/BombItem.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class BombItem : Item
 {
     private LineRenderer lineRenderer;
+    private BoxCollider2D bombBody;
     private CircleCollider2D bombRange;
 
     private bool isHanded = false;
@@ -30,7 +31,9 @@ public class BombItem : Item
     private void Awake()
     {
         lineRenderer = GetComponent<LineRenderer>();
+        bombBody = GetComponent<BoxCollider2D>();
         bombRange = GetComponent<CircleCollider2D>();
+        bombBody.enabled = false;
         bombRange.enabled = false;
 
         EraseAimLine();
@@ -88,10 +91,9 @@ public class BombItem : Item
     private IEnumerator ThrowBomb()
     {
         transform.SetParent(null);
+        bombBody.enabled = true;
 
         Vector2 direction = endPosition - startPosition;
-        direction = direction.normalized * distance;
-
 
         while(isCrashed == false && Vector3.Magnitude(transform.position - startPosition) < distance)
         {
@@ -104,7 +106,6 @@ public class BombItem : Item
 
     private IEnumerator Bomb()
     {
-        Debug.Log("Bomb!");
         bombRange.enabled = true;
 
         // 충돌 감지를 위한 1프레임 대기
@@ -129,7 +130,14 @@ public class BombItem : Item
     private void GetLineTransform()
     {
         startPosition = transform.position;
+
+        // 마우스 위치를 받아온다.
         endPosition = Camera.main.ScreenToWorldPoint(new Vector3(Input.mousePosition.x, Input.mousePosition.y, 0));
         endPosition.z = 0;
+
+        // 조준선의 길이를 고정
+        Vector3 direction = endPosition - startPosition;
+        direction = direction.normalized * distance;
+        endPosition = direction + startPosition;
     }
 }

--- a/Assets/03. Scripts/Item/Item/Items/BombItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/BombItem.cs
@@ -28,8 +28,10 @@ public class BombItem : HandItem
         isHanded = false;
     }
 
-    private void Awake()
+    protected override void Awake()
     {
+        base.Awake();
+
         lineRenderer = GetComponent<LineRenderer>();
         bombBody = GetComponent<BoxCollider2D>();
         bombRange = GetComponent<CircleCollider2D>();

--- a/Assets/03. Scripts/Item/Item/Items/BombItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/BombItem.cs
@@ -2,7 +2,7 @@ using DG.Tweening;
 using System.Collections;
 using UnityEngine;
 
-public class BombItem : Item
+public class BombItem : HandItem
 {
     private LineRenderer lineRenderer;
     private BoxCollider2D bombBody;
@@ -111,7 +111,7 @@ public class BombItem : Item
         // 충돌 감지를 위한 1프레임 대기
         yield return null;
         // TODO: 폭발 이펙트
-        Destroy(gameObject);
+        DestroyItem();
     }
 
     public void DrawAimLine()

--- a/Assets/03. Scripts/Item/Item/Items/HandItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/HandItem.cs
@@ -2,9 +2,10 @@ using UnityEngine;
 
 public class HandItem : Item
 {
+    [SerializeField]
     protected QuickSlot quickSlot;
 
-    private void Awake()
+    protected virtual void Awake()
     {
         quickSlot = GameObject.Find("Quick Slot").GetComponent<QuickSlot>();
     }

--- a/Assets/03. Scripts/Item/Item/Items/HandItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/HandItem.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class HandItem : Item
+{
+    protected QuickSlot quickSlot;
+
+    private void Awake()
+    {
+        quickSlot = GameObject.Find("Quick Slot").GetComponent<QuickSlot>();
+    }
+
+    protected void DestroyItem()
+    {
+        quickSlot.currentSlot.ClearSlot();
+        quickSlot.ClearQuickSlot();
+        Destroy(gameObject);
+    }
+}

--- a/Assets/03. Scripts/Item/Item/Items/HandItem.cs.meta
+++ b/Assets/03. Scripts/Item/Item/Items/HandItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6b894103179c174790b96f19d604940
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03. Scripts/Item/Item/Items/Item.cs
+++ b/Assets/03. Scripts/Item/Item/Items/Item.cs
@@ -6,7 +6,6 @@ public class Item : MonoBehaviour
     public ItemData itemData;
     // 변하는 정보들 (각 아이템마다 적용)
     public int count = 1;
-    public bool isEquiped = false;
 
     /// <summary>
     /// 아이템을 사용한다.

--- a/Assets/03. Scripts/Item/Item/Items/KeyItem.cs
+++ b/Assets/03. Scripts/Item/Item/Items/KeyItem.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public class KeyItem : Item
+public class KeyItem : HandItem
 {
     public override void ActivateItem()
     {

--- a/Assets/03. Scripts/Item/ItemData/ItemData.cs
+++ b/Assets/03. Scripts/Item/ItemData/ItemData.cs
@@ -32,6 +32,6 @@ public class ItemData : ScriptableObject
     public int priority = 0;
 
     [Header("아이템 분류")]
-    public PurposeTag itemTag;
+    public PurposeTag purposeTag;
     public UseTag useTag;
 }

--- a/Assets/03. Scripts/Player/PlayerHand.cs
+++ b/Assets/03. Scripts/Player/PlayerHand.cs
@@ -12,5 +12,6 @@ public class PlayerHand : MonoBehaviour
     public void HandItem(Item item)
     {
         currentItem = item;
+        item.gameObject.SetActive(true);
     }
 }

--- a/Assets/04. Items/Explore Items/Armor.asset
+++ b/Assets/04. Items/Explore Items/Armor.asset
@@ -19,8 +19,5 @@ MonoBehaviour:
     1\uD68C \uB9C9\uC544\uC900\uB2E4."
   count: 78
   priority: 1
-  useItemEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  itemTag: 1
+  purposeTag: 1
   useTag: 2

--- a/Assets/04. Items/Explore Items/Bomb.asset
+++ b/Assets/04. Items/Explore Items/Bomb.asset
@@ -19,5 +19,5 @@ MonoBehaviour:
     \uC218 \uC788\uB2E4."
   count: 1
   priority: 3
-  itemTag: 1
+  purposeTag: 1
   useTag: 1

--- a/Assets/04. Items/Explore Items/Flashlight.asset
+++ b/Assets/04. Items/Explore Items/Flashlight.asset
@@ -18,20 +18,5 @@ MonoBehaviour:
   description: "\uC5B4\uB450\uC6B4 \uBC14\uB2E4\uB97C \uBC1D\uAC8C \uBE44\uCDB0\uC900\uB2E4."
   count: 1
   priority: 2
-  useItemEvent:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 2003766445664713525, guid: abb96e1d2de6f0a449ac65318548158b, type: 3}
-        m_TargetAssemblyTypeName: LampSetter, Assembly-CSharp
-        m_MethodName: CreateLamp
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  itemTag: 1
+  purposeTag: 1
   useTag: 0

--- a/Assets/05. Prefebs/Items/Bomb.prefab
+++ b/Assets/05. Prefebs/Items/Bomb.prefab
@@ -143,7 +143,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemData: {fileID: 11400000, guid: cc5380d0a95e897489ceda1078d4b843, type: 2}
   count: 1
-  isEquiped: 0
   distance: 10
   isCrashed: 0
   speed: 0.6
@@ -382,7 +381,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 2
+  m_Radius: 3
 --- !u!50 &5275613512160364165
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/05. Prefebs/UI/Inventory/Inventory.prefab
+++ b/Assets/05. Prefebs/UI/Inventory/Inventory.prefab
@@ -2023,7 +2023,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1501488476279655239}
         m_TargetAssemblyTypeName: Inventory, Assembly-CSharp
-        m_MethodName: SortInventory
+        m_MethodName: DropExploreItems
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}


### PR DESCRIPTION
# 개요
- 아이템을 떨구는 기능을 추가했습니다.
- 폭탄의 조준선 길이를 고정하고, 사용 후 퀵슬롯에서 해제되게 수정했습니다.

# 변경 사항 (새로 추가된 기능)
- Inventory.cs에 DropExploreItems 함수를 추가하였습니다. 이 함수는 모든 슬롯을 순회하며, ExploreItem을 찾아 제거합니다.
- 만약 해당 아이템이 장착 중이라면, 장착 해제 후 삭제합니다.
- 폭탄의 조준선 길이를 일정한 길이(10f)로 고정하였습니다. 이는 실제 폭탄이 날아가는 최대 거리와 같습니다.
- 아이템 장착/해제, 사용 시 아이템, 슬롯, 퀵슬롯에 얽힌 문제들을 해결했습니다. 예를 들면, 사용 후에도 인벤토리에 남아있는 현상 등입니다. 이제 완벽하게 동작합니다.

# 해결되지 않은 문제
- Armor도 구현하려 했으나 Player.cs의 보호 수준에 가로막혔습니다. 충돌 방지를 위해 주석으로 설계만 해뒀습니다.
